### PR TITLE
Don't replace Java primitive types

### DIFF
--- a/protocol-parser-generator/src/main/java/org/infinispan/ppg/generator/Action.java
+++ b/protocol-parser-generator/src/main/java/org/infinispan/ppg/generator/Action.java
@@ -88,9 +88,13 @@ class Action implements Element {
          if (requiresSpace) {
             sb.append(' ');
          }
-         if (Character.isLetter(firstChar) || firstChar == '@') {
+         boolean reservedWord = switch (item) {
+            case "boolean", "byte", "char", "double", "float", "int", "long", "short" -> true;
+            default -> false;
+         };
+         if (!reservedWord && Character.isLetter(firstChar) || firstChar == '@') {
             requiresSpace = true;
-            // TODO omit java keywords?
+
             Resolvable resolvable = grammar.qualified.get(item);
             if (resolvable != null) {
                sb.append(resolvable.sourceName());


### PR DESCRIPTION
Action code blocks shouldn't replace common Java keywords such as int and long. These types are required when parsing various protocols. Users should reference with the namespace directly if they need to reference the fields that are generated instead.